### PR TITLE
Refactor service (internally) and extend connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.1] - 2024-XX-YY
 ### Added
 - Generalized `echo()` to accept an `Echo` class.
+- Added `Service` class, that can be asked about models, and can generate `Model`s.
 - Added `image(...)` method to `Model`, for multi-modal models.
 - Added `response.value`, which return the JSON `dict` of the reply, or `None`.
 - Added new `host` argument to `connect`, which allows for user "virtual" models.

--- a/src/haverscript/__init__.py
+++ b/src/haverscript/__init__.py
@@ -14,10 +14,11 @@ from .haverscript import (
     Model,
     Response,
     ServiceProvider,
+    Ollama,
+    Service,
     accept,
     connect,
     fresh,
-    list_models,
     valid_json,
 )
 
@@ -31,7 +32,8 @@ __all__ = [
     "connect",
     "fresh",
     "valid_json",
-    "list_models",
+    "Service",
+    "Ollama",
     "LLMError",
     "LLMConfigurationError",
     "LLMRequestError",

--- a/src/haverscript/together.py
+++ b/src/haverscript/together.py
@@ -17,7 +17,7 @@ class TogetherMetrics(Metrics):
 
 
 class Together(ServiceProvider):
-    def __init__(self, hostname) -> None:
+    def __init__(self) -> None:
         self.key = os.getenv("TOGETHER_API_KEY")
         assert self.key is not None, "TOGETHER_API_KEY is not set to key"
 

--- a/tests/e2e/test_e2e_haverscript.py
+++ b/tests/e2e/test_e2e_haverscript.py
@@ -55,7 +55,7 @@ from haverscript.together import Together
 from tenacity import stop_after_attempt, wait_fixed
 
 session = connect""",
-                '("mistral")': '("meta-llama/Meta-Llama-3-8B-Instruct-Lite", service=Together).retry_policy(stop=stop_after_attempt(5), wait=wait_fixed(2))',
+                '("mistral")': '("meta-llama/Meta-Llama-3-8B-Instruct-Lite", service=Together()).retry_policy(stop=stop_after_attempt(5), wait=wait_fixed(2))',
             },
         ).splitlines()
     )
@@ -67,7 +67,7 @@ def test_together(tmp_path, file_regression):
         run_example(
             "examples/together/main.py",
             tmp_path,
-            {"connect(model, service=Together)": "connect(model, service=Together)"},
+            {"connect(model, service=Together)": "connect(model, service=Together())"},
         ).splitlines()
     )
     assert lines > 10 and lines < 1000


### PR DESCRIPTION
The PR added a class Provider, that has two methods
 * `list() -> [str]` that lists the models supported by the provider, and
 * `model(model_name : str) -> Model` that builds a  `Model`.

`connect` now can return a `Provider`, if no model name is supplied.

`list_models` has been removed.